### PR TITLE
Start web API via Uvicorn

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ approaches, but dRAGon will reduce the cost of determining how a GM would rule i
 
 Of course, it is stll up to the GM how they will rule in such a case.
 
+## Running
+
+Launch the web API by running the package with Python:
+
+```
+python -m dragon
+```
+
+This starts a Uvicorn server on http://0.0.0.0:8000.
+
 ## Critical Features
 
 - dRAGon will answer generic questions about rules. e.g. "What are the rules fighting in difficult terrain" or "What story phase

--- a/dragon/__main__.py
+++ b/dragon/__main__.py
@@ -1,0 +1,14 @@
+import uvicorn
+
+from .webapi import app
+
+
+def main() -> None:
+    """Run the dRAGon web API using Uvicorn."""
+    config = uvicorn.Config(app, host="0.0.0.0", port=8000)
+    server = uvicorn.Server(config)
+    server.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `__main__` module to launch FastAPI app with Uvicorn's programmatic API
- Document running the app via `python -m dragon`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b33407f800832dbebef86bbdb6fc86