### PR TITLE
Fix missing package imports

### DIFF
--- a/dragon/search.py
+++ b/dragon/search.py
@@ -6,7 +6,7 @@ from whoosh.index import create_in, open_dir
 from whoosh.qparser import QueryParser
 from whoosh.qparser import OrGroup
 
-from config import config
+from .config import config
 
 
 ## Define search method 

--- a/dragon/webapi.py
+++ b/dragon/webapi.py
@@ -3,8 +3,8 @@ from langchain.prompts import PromptTemplate
 from langchain_openai import OpenAI
 from pydantic import BaseModel
 
-import search
-from config import config
+from . import search
+from .config import config
 
 
 class Query(BaseModel):


### PR DESCRIPTION
## Summary
- use package-relative imports for internal modules

## Testing
- `python -c "import dragon.webapi"` *(fails: ForwardRef._evaluate missing keyword 'recursive_guard')*
- `python -c "import dragon.search"` *(fails: ForwardRef._evaluate missing keyword 'recursive_guard')*
- `pip install 'pydantic<2'` *(fails: 403 Client Error)*

------
https://chatgpt.com/codex/tasks/task_e_68b339724c34832dacc65a2a0b4be494